### PR TITLE
Remove arc clone from server start

### DIFF
--- a/src/server/http.rs
+++ b/src/server/http.rs
@@ -8,7 +8,7 @@ use crate::proxy_service::{gateway_body::GatewayBody, proxy_bridge::ProxyBridge}
 
 pub async fn start_http_server(
     address: SocketAddr,
-    proxy_bridge: Arc<ProxyBridge>,
+    proxy_bridge: &Arc<ProxyBridge>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let tcp_listener = TcpListener::bind(&address).await?;
 

--- a/src/server/https.rs
+++ b/src/server/https.rs
@@ -19,7 +19,7 @@ use crate::proxy_service::{gateway_body::GatewayBody, proxy_bridge::ProxyBridge}
 
 pub async fn start_https_server(
     address: SocketAddr,
-    proxy_bridge: Arc<ProxyBridge>,
+    proxy_bridge: &Arc<ProxyBridge>,
     key_path: &str,
     cert_path: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {

--- a/src/server/server_manager.rs
+++ b/src/server/server_manager.rs
@@ -26,13 +26,13 @@ impl ServerManager {
         if self.settings.enable_https {
             start_https_server(
                 address,
-                Arc::clone(&self.proxy_bridge),
+                &self.proxy_bridge,
                 self.settings.key_path.as_ref().unwrap(),
                 self.settings.cert_path.as_ref().unwrap(),
             )
             .await
         } else {
-            start_http_server(address, Arc::clone(&self.proxy_bridge)).await
+            start_http_server(address, &self.proxy_bridge).await
         }
     }
 }


### PR DESCRIPTION
Remove unnecessary arc cloning, when starting an http/https server 